### PR TITLE
fix: improve platform_fee parsing for multiple formats

### DIFF
--- a/src/mappers/escrow-mapper.ts
+++ b/src/mappers/escrow-mapper.ts
@@ -172,12 +172,9 @@ if (key === "platform_fee") {
   // Check if it's a string (might already be formatted)
   if (isStrLike(val)) {
     const str = val.string.trim();
-    // If it already has %, return as-is
-    if (str.includes('%')) {
-      return str;
-    }
-    // Otherwise, try to parse as number
-    const num = parseFloat(str);
+    // Remove % if present and parse the number
+    const cleanStr = str.replace('%', '').trim();
+    const num = parseFloat(cleanStr);
     if (!isNaN(num)) {
       // If > 100, treat as basis points; otherwise as percentage
       return (num > 100 ? num / 100 : num).toFixed(2) + "%";


### PR DESCRIPTION
Before:
The platform_fee was only handled when it came as i128 and always divided by 100, causing incorrect formatting when the value came as a direct percentage or in other formats.

After:
The code automatically detects the format and correctly formats the percentage, regardless of how the data arrives from the RPC.

#26 

<img width="1512" height="686" alt="Captura de pantalla 2025-12-04 a la(s) 6 12 19 p  m" src="https://github.com/user-attachments/assets/3040a8d8-3054-4239-9571-0ae8bd5ca09f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing data values in mappers now return a clear placeholder ("N/A") instead of empty/undefined results.
  * Platform fee parsing strengthened to handle multiple input encodings and formats, producing a consistent percentage string (e.g., "X.XX%") for reliable display and calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->