### PR TITLE
Remove mounted state from NetworkProvider

### DIFF
--- a/src/contexts/NetworkContext.tsx
+++ b/src/contexts/NetworkContext.tsx
@@ -18,7 +18,6 @@ interface NetworkProviderProps {
 
 export function NetworkProvider({ children }: NetworkProviderProps) {
   const [currentNetwork, setCurrentNetwork] = useState<NetworkType>(getDefaultNetwork());
-  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);


### PR DESCRIPTION
Removed unused mounted state from NetworkProvider.
  const [mounted, setMounted] = useState(false);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal state management within the network context layer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->