### PR TITLE
fix: support updated mainnet contract schema and persistent storage

### DIFF
--- a/src/hooks/useEscrowData.ts
+++ b/src/hooks/useEscrowData.ts
@@ -31,6 +31,16 @@ export function useEscrowData(
 
     try {
       const data = await getLedgerKeyContractCode(contractId, network);
+
+      if (data.length === 0) {
+        setRaw(null);
+        setOrganized(null);
+        setError(
+          "Escrow data parsed but no fields found. The contract schema may have changed.",
+        );
+        return;
+      }
+
       setRaw(data);
       setOrganized(organizeEscrowData(data, contractId, isMobile));
     } catch (e) {

--- a/src/mappers/escrow-mapper.ts
+++ b/src/mappers/escrow-mapper.ts
@@ -66,9 +66,11 @@ function getMap(
 function getI128(
   m: Record<string, EscrowValue>,
   k: string,
-): I128Like | undefined {
+): I128Like | U128Like | undefined {
   const v = m[k] as unknown;
-  return isI128Like(v) ? (v as I128Like) : undefined;
+  if (isI128Like(v)) return v as I128Like;
+  if (isU128Like(v)) return v as U128Like;
+  return undefined;
 }
 
 type BoolLike = { bool: boolean };
@@ -78,6 +80,9 @@ type MapEntry = { key: { symbol: string }; val: EscrowValue };
 type MapLikePresent = { map: MapEntry[] };
 type I128Parts = { hi?: number | string; lo?: number | string };
 type I128Like = { i128: string | I128Parts };
+type U128Like = { u128: string | I128Parts };
+type U32Like = { u32: number };
+type U64Like = { u64: string | number };
 
 function isBoolLike(v: unknown): v is BoolLike {
   return !!v && typeof (v as Record<"bool", unknown>).bool === "boolean";
@@ -92,12 +97,11 @@ function isMapLike(v: unknown): v is MapLikePresent {
   const m = v as { map?: unknown };
   return !!v && Array.isArray(m.map);
 }
-// (If you don’t use isVecLike anywhere, delete it entirely to fix the unused error)
 
 function isI128Parts(v: unknown): v is I128Parts {
   if (!v || typeof v !== "object") return false;
   const r = v as Record<string, unknown>;
-  return "hi" in r || "lo" in r; // presence indicates the {hi,lo} form
+  return "hi" in r || "lo" in r;
 }
 
 function isI128Like(v: unknown): v is I128Like {
@@ -108,8 +112,30 @@ function isI128Like(v: unknown): v is I128Like {
   return typeof raw === "string" || isI128Parts(raw);
 }
 
-function i128ToBigIntFlexibleSafe(v: I128Like): bigint | null {
-  const raw = v.i128;
+function isU128Like(v: unknown): v is U128Like {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (!("u128" in r)) return false;
+  const raw = (r as { u128: unknown }).u128;
+  return typeof raw === "string" || isI128Parts(raw);
+}
+
+function isU32Like(v: unknown): v is U32Like {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as Record<string, unknown>).u32 === "number"
+  );
+}
+
+function isU64Like(v: unknown): v is U64Like {
+  if (!v || typeof v !== "object") return false;
+  const u64 = (v as Record<string, unknown>).u64;
+  return u64 !== undefined && (typeof u64 === "string" || typeof u64 === "number");
+}
+
+function i128ToBigIntFlexibleSafe(v: I128Like | U128Like): bigint | null {
+  const raw = "i128" in v ? v.i128 : v.u128;
   if (typeof raw === "string") {
     try {
       return BigInt(raw);
@@ -192,18 +218,13 @@ export const extractValue = (
       return str;
     }
 
-    // Check for u32 format
-    const u32Val = val as { u32?: number };
-    if (u32Val && typeof u32Val.u32 === "number") {
-      const num = u32Val.u32;
-      return (num > 100 ? num / 100 : num).toFixed(2) + "%";
+    if (isU32Like(val)) {
+      return (val.u32 > 100 ? val.u32 / 100 : val.u32).toFixed(2) + "%";
     }
 
-    // Check for u64 format
-    const u64Val = val as { u64?: string | number };
-    if (u64Val && u64Val.u64 !== undefined) {
+    if (isU64Like(val)) {
       const num =
-        typeof u64Val.u64 === "string" ? parseInt(u64Val.u64, 10) : u64Val.u64;
+        typeof val.u64 === "string" ? parseInt(val.u64, 10) : val.u64;
       if (!isNaN(num)) {
         return (num > 100 ? num / 100 : num).toFixed(2) + "%";
       }
@@ -228,27 +249,39 @@ export const extractValue = (
     if (key === "platform_fee") {
       const big = i128ToBigIntFlexibleSafe(val);
       if (big === null) return "N/A";
-
-      // Platform fee might come as:
-      // - Basis points (500 = 5%) - divide by 100
-      // - Direct percentage (5 = 5%) - use as-is
-      // - Percentage with decimals (500 = 5.00%) - divide by 100
-      // Let's check the actual value to determine the format
       const numValue = Number(big);
-
-      // If value is > 100, it's likely basis points (divide by 100)
-      // If value is <= 100, it might be direct percentage
-      if (numValue > 100) {
-        return (numValue / 100).toFixed(2) + "%";
-      } else {
-        // Value is <= 100, treat as direct percentage
-        return numValue.toFixed(2) + "%";
-      }
+      return (numValue > 100 ? numValue / 100 : numValue).toFixed(2) + "%";
     }
     const d = safeDecimals(getDecimalsFromEscrowMap(data));
     const big = i128ToBigIntFlexibleSafe(val);
     if (big === null) return "N/A";
     return (Number(big) / Math.pow(10, d)).toFixed(d);
+  }
+
+  // u128 — same binary layout as i128 but unsigned (new contract types may use this)
+  if (isU128Like(val)) {
+    if (key === "platform_fee") {
+      const big = i128ToBigIntFlexibleSafe(val);
+      if (big === null) return "N/A";
+      const numValue = Number(big);
+      return (numValue > 100 ? numValue / 100 : numValue).toFixed(2) + "%";
+    }
+    const d = safeDecimals(getDecimalsFromEscrowMap(data));
+    const big = i128ToBigIntFlexibleSafe(val);
+    if (big === null) return "N/A";
+    return (Number(big) / Math.pow(10, d)).toFixed(d);
+  }
+
+  // u64 — for numeric fields encoded as u64
+  if (isU64Like(val)) {
+    const num =
+      typeof val.u64 === "string" ? parseInt(val.u64, 10) : val.u64;
+    if (isNaN(num)) return "N/A";
+    if (key === "platform_fee") {
+      return (num > 100 ? num / 100 : num).toFixed(2) + "%";
+    }
+    const d = safeDecimals(getDecimalsFromEscrowMap(data));
+    return (num / Math.pow(10, d)).toFixed(d);
   }
 
   return "N/A";
@@ -434,7 +467,7 @@ export const organizeEscrowData = (
   // balance
   let balance = String(extractValue(escrowData, "balance", isMobile));
   const balanceRaw = escrowData.find((e) => e.key.symbol === "balance")?.val;
-  if (isI128Like(balanceRaw)) {
+  if (isI128Like(balanceRaw) || isU128Like(balanceRaw)) {
     const big = i128ToBigIntFlexibleSafe(balanceRaw);
     const d = safeDecimals(getDecimalsFromEscrowMap(escrowData));
     balance =

--- a/src/utils/ledgerkeycontract.ts
+++ b/src/utils/ledgerkeycontract.ts
@@ -1,4 +1,4 @@
-import { Contract } from "@stellar/stellar-sdk";
+import { Contract, xdr, Address } from "@stellar/stellar-sdk";
 import { NetworkType, getNetworkConfig } from "@/lib/network-config";
 
 // Define types for the escrow data map
@@ -7,7 +7,11 @@ interface EscrowKey {
 }
 
 export interface EscrowValue {
-  i128?: { hi: number; lo: number };
+  i128?: { hi: number | string; lo: number | string };
+  u128?: { hi: number | string; lo: number | string };
+  u32?: number;
+  u64?: string | number;
+  i64?: string | number;
   string?: string;
   address?: string;
   bool?: boolean;
@@ -24,17 +28,56 @@ interface EscrowMapEntry {
 export type EscrowMap = EscrowMapEntry[];
 
 interface StorageEntry {
-  key: { vec?: { symbol: string }[] };
+  key: { vec?: { symbol: string }[]; symbol?: string };
   val: { map?: EscrowMapEntry[] };
 }
 
-export async function getLedgerKeyContractCode(
+// Possible keys the escrow contract might use
+const ESCROW_KEYS = ["Escrow", "EscrowData", "escrow", "State", "Data"];
+
+function matchesEscrowKey(entry: StorageEntry): boolean {
+  for (const k of ESCROW_KEYS) {
+    // Vec format: { vec: [{ symbol: "Escrow" }] }
+    if (entry.key?.vec && entry.key.vec[0]?.symbol === k) return true;
+    // Symbol format: { symbol: "Escrow" }
+    if (entry.key?.symbol === k) return true;
+  }
+  return false;
+}
+
+/**
+ * Build a LedgerKey for persistent ContractData with a Vec[Symbol] key.
+ * This is how Soroban DataKey enum variants are stored (e.g. DataKey::Escrow).
+ */
+function buildPersistentEscrowLedgerKey(
   contractId: string,
-  network: NetworkType = "testnet",
-): Promise<EscrowMap> {
-  try {
-    const ledgerKey = new Contract(contractId).getFootprint();
-    const keyBase64 = ledgerKey.toXDR("base64");
+  keySymbol: string,
+): string {
+  const ledgerKey = xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: new Address(contractId).toScAddress(),
+      key: xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(keySymbol)]),
+      durability: xdr.ContractDataDurability.persistent(),
+    }),
+  );
+  return ledgerKey.toXDR("base64");
+}
+
+/**
+ * Try reading the escrow from persistent storage.
+ * Used as a fallback when contract_instance.storage is null (new contracts).
+ */
+async function fetchFromPersistentStorage(
+  contractId: string,
+  rpcUrl: string,
+): Promise<EscrowMap | null> {
+  for (const keySymbol of ESCROW_KEYS) {
+    let keyBase64: string;
+    try {
+      keyBase64 = buildPersistentEscrowLedgerKey(contractId, keySymbol);
+    } catch {
+      continue;
+    }
 
     const requestBody = {
       jsonrpc: "2.0",
@@ -46,65 +89,104 @@ export async function getLedgerKeyContractCode(
       },
     };
 
-    const networkConfig = getNetworkConfig(network);
-    const res = await fetch(networkConfig.rpcUrl, {
+    const res = await fetch(rpcUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(requestBody),
     });
 
-    if (!res.ok) {
-      throw new Error(`HTTP error! Status: ${res.status}`);
-    }
+    if (!res.ok) continue;
 
     const json = await res.json();
-
-    if (json.error) {
-      throw new Error(json.error.message || "Failed to fetch ledger entries");
-    }
+    if (json.error || !json.result?.entries?.length) continue;
 
     const entry = json.result.entries[0];
-    if (!entry) {
-      throw new Error("No ledger entry found for this contract ID");
-    }
-
-    const contractData = entry?.dataJson?.contract_data?.val?.contract_instance;
-    if (!contractData) {
-      throw new Error("No contract instance data found");
-    }
-
-    const storage = contractData.storage;
-    if (!storage || !Array.isArray(storage)) {
-      throw new Error("No storage data found or storage is not an array");
-    }
+    const val = entry?.dataJson?.contract_data?.val;
 
     console.log(
-      "[DEBUG] Raw contract storage:",
+      `[DEBUG] Persistent storage (key="${keySymbol}"):`,
+      JSON.stringify(val, null, 2),
+    );
+
+    if (val?.map && Array.isArray(val.map)) {
+      return val.map as EscrowMap;
+    }
+  }
+  return null;
+}
+
+export async function getLedgerKeyContractCode(
+  contractId: string,
+  network: NetworkType = "testnet",
+): Promise<EscrowMap> {
+  const networkConfig = getNetworkConfig(network);
+  const { rpcUrl } = networkConfig;
+
+  // ── Step 1: fetch contract instance storage ──────────────────────────────
+  const instanceKey = new Contract(contractId).getFootprint();
+  const instanceKeyBase64 = instanceKey.toXDR("base64");
+
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 8675309,
+      method: "getLedgerEntries",
+      params: { keys: [instanceKeyBase64], xdrFormat: "json" },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`RPC request failed (HTTP ${res.status})`);
+  }
+
+  const json = await res.json();
+
+  if (json.error) {
+    throw new Error(json.error.message || "RPC returned an error");
+  }
+
+  const entry = json.result?.entries?.[0];
+  if (!entry) {
+    throw new Error(
+      "Contract not found. Check the contract ID and selected network.",
+    );
+  }
+
+  const contractData = entry?.dataJson?.contract_data?.val?.contract_instance;
+  if (!contractData) {
+    throw new Error("Contract is not a Soroban instance contract.");
+  }
+
+  const storage = contractData.storage;
+
+  // ── Step 2: try instance storage first ───────────────────────────────────
+  if (storage && Array.isArray(storage)) {
+    console.log(
+      "[DEBUG] Raw contract instance storage:",
       JSON.stringify(storage, null, 2),
     );
 
-    // Find the escrow entry
-    const escrowEntry = storage.find(
-      (s: StorageEntry) => s.key?.vec && s.key.vec[0]?.symbol === "Escrow",
-    );
+    const escrowEntry = storage.find((s: StorageEntry) => matchesEscrowKey(s));
 
-    if (!escrowEntry) {
-      throw new Error("Escrow data not found in the contract storage");
+    if (escrowEntry) {
+      if (!escrowEntry.val?.map || !Array.isArray(escrowEntry.val.map)) {
+        return [];
+      }
+      return escrowEntry.val.map as EscrowMap;
     }
-
-    if (!escrowEntry.val || typeof escrowEntry.val !== "object") {
-      throw new Error("Escrow value is missing or not a valid object");
-    }
-
-    if (!escrowEntry.val.map || !Array.isArray(escrowEntry.val.map)) {
-      return [];
-    }
-
-    return escrowEntry.val.map as EscrowMap;
-  } catch (error) {
-    console.error("Error fetching escrow data:", error);
-    return [];
   }
+
+  // ── Step 3: instance storage is null/empty → try persistent storage ──────
+  // New contract versions store escrow data via env.storage().persistent()
+  const persistentMap = await fetchFromPersistentStorage(contractId, rpcUrl);
+  if (persistentMap !== null) {
+    return persistentMap;
+  }
+
+  throw new Error(
+    "Escrow data not found in contract storage. " +
+      "This contract may not be a Trustless Work escrow, or the contract schema has changed.",
+  );
 }


### PR DESCRIPTION
## Summary

Closes #64

- **Persistent storage fallback**: new contracts store escrow data via `env.storage().persistent()` instead of instance storage. When `contract_instance.storage` is `null`, the viewer now queries persistent storage directly using the `DataKey::Escrow` ledger key.
- **Broader type support**: added type guards and handlers for `u32`, `u64`, and `u128` in the mapper so fields that changed type from `i128` still render correctly (e.g. `platform_fee`, `receiver_memo`).
- **Both key formats**: the storage entry lookup now handles both `{ vec: [{ symbol: "Escrow" }] }` and `{ symbol: "Escrow" }` key shapes.
- **Proper error propagation**: parsing errors now surface to the UI with clear messages instead of silently returning empty data.

## Test plan

- [ ] Load a known mainnet escrow from the updated contract — properties, roles, milestones and flags should render correctly
- [ ] Load a testnet escrow from the previous contract version — no regression
- [ ] Enter an invalid contract ID — error message shown, no N/A card rendered
- [ ] Enter a contract ID on the wrong network — clear "not found" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty or invalid escrow contract data.
  * Enhanced error detection for contract data fetch failures and schema mismatches.

* **New Features**
  * Added support for unsigned 128-bit numeric values in escrow contracts.
  * Expanded numeric type support for platform fees and escrow balance calculations.
  * Implemented fallback mechanism for contract data retrieval when primary source is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->