### PR TITLE
fix: show milestone receivers on milestone cards

### DIFF
--- a/src/components/escrow/desktop-view.tsx
+++ b/src/components/escrow/desktop-view.tsx
@@ -125,6 +125,7 @@ export const DesktopView = ({ organized, network }: DesktopViewProps) => {
                     resolved_flag={milestone.resolved_flag}
                     signer={milestone.signer}
                     approver={milestone.approver}
+                    receiver={milestone.receiver}
                   />
                 </motion.div>
               ))}

--- a/src/components/escrow/tab-view.tsx
+++ b/src/components/escrow/tab-view.tsx
@@ -149,6 +149,7 @@ export const TabView = ({ organized, network }: TabViewProps) => {
                       resolved_flag={milestone.resolved_flag}
                       signer={milestone.signer}
                       approver={milestone.approver}
+                      receiver={milestone.receiver}
                     />
                   ))}
                 </div>

--- a/src/components/shared/milestone-card.tsx
+++ b/src/components/shared/milestone-card.tsx
@@ -16,7 +16,11 @@ interface MilestoneProps {
   resolved_flag?: boolean;
   signer?: string;
   approver?: string;
+  receiver?: string;
 }
+
+const formatAddressForCard = (address: string): string =>
+  address.length > 18 ? `${address.slice(0, 8)}...${address.slice(-6)}` : address;
 
 export const MilestoneCard = ({
   index,
@@ -31,6 +35,7 @@ export const MilestoneCard = ({
   resolved_flag,
   signer,
   approver,
+  receiver,
 }: MilestoneProps) => {
   const cardVariants = {
     hidden: { opacity: 0, y: 20 },
@@ -109,8 +114,14 @@ export const MilestoneCard = ({
               </div>
             )}
 
-            {(signer || approver) && (
+            {(receiver || signer || approver) && (
               <div className="flex flex-col gap-1 mt-2 text-xs text-muted-foreground">
+                {receiver && (
+                  <span className="break-all">
+                    <span className="font-medium">Receiver:</span>{" "}
+                    <span title={receiver}>{formatAddressForCard(receiver)}</span>
+                  </span>
+                )}
                 {signer && (
                   <span>
                     <span className="font-medium">Signer:</span> {signer}

--- a/src/mappers/escrow-mapper.ts
+++ b/src/mappers/escrow-mapper.ts
@@ -17,6 +17,7 @@ export interface ParsedMilestone {
   resolved_flag?: boolean;
   signer?: string;
   approver?: string;
+  receiver?: string;
 }
 
 export type EscrowFlags = {
@@ -372,6 +373,14 @@ export const extractMilestones = (
             resolved_flag,
             signer: getAddr(milestoneMap, "signer"),
             approver: getAddr(milestoneMap, "approver"),
+            // Current multi-release milestone storage uses `receiver` for the
+            // milestone-level fund recipient. Keep compatible fallbacks for
+            // older/proposed schemas that may name the same address differently.
+            receiver:
+              getAddr(milestoneMap, "receiver") ??
+              getAddr(milestoneMap, "receiver_address") ??
+              getAddr(milestoneMap, "recipient") ??
+              getAddr(milestoneMap, "recipient_address"),
           },
         ];
       }


### PR DESCRIPTION
## Summary
- Add optional `receiver` to normalized multi-release milestones.
- Extract milestone-level receiver addresses from `receiver` (with compatible fallbacks for `receiver_address`, `recipient`, and `recipient_address`).
- Pass receiver data through desktop and mobile milestone views and display it safely on each milestone card without changing signer/approver rendering.

## Contract storage note
The issue identifies `receiver` as the current milestone-level receiver field; this implementation reads that field first and keeps fallback names only for schema compatibility.

## Verification
- `npx tsc --noEmit`
- `npm run build` (passes; existing Next/Stellar dependency warnings about dynamic `require` remain)
- `git diff --check`
- Added-line security scan: 0 findings
- Independent reviewer: passed

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone cards now display receiver information in a truncated, readable format with full address visible on hover

<!-- end of auto-generated comment: release notes by coderabbit.ai -->