### PR TITLE
Show per-milestone receiver on multi-release milestone cards

### DIFF
--- a/src/components/escrow/desktop-view.tsx
+++ b/src/components/escrow/desktop-view.tsx
@@ -125,6 +125,7 @@ export const DesktopView = ({ organized, network }: DesktopViewProps) => {
                     resolved_flag={milestone.resolved_flag}
                     signer={milestone.signer}
                     approver={milestone.approver}
+                    receiver={milestone.receiver}
                   />
                 </motion.div>
               ))}

--- a/src/components/escrow/tab-view.tsx
+++ b/src/components/escrow/tab-view.tsx
@@ -149,6 +149,7 @@ export const TabView = ({ organized, network }: TabViewProps) => {
                       resolved_flag={milestone.resolved_flag}
                       signer={milestone.signer}
                       approver={milestone.approver}
+                      receiver={milestone.receiver}
                     />
                   ))}
                 </div>

--- a/src/components/shared/milestone-card.tsx
+++ b/src/components/shared/milestone-card.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatusBadge } from "./status-badge";
 import { InfoTooltip } from "./info-tooltip";
+import { DetailRow } from "./detail-row";
 import { motion } from "framer-motion";
 
 interface MilestoneProps {
@@ -16,6 +17,7 @@ interface MilestoneProps {
   resolved_flag?: boolean;
   signer?: string;
   approver?: string;
+  receiver?: string;
 }
 
 export const MilestoneCard = ({
@@ -31,6 +33,7 @@ export const MilestoneCard = ({
   resolved_flag,
   signer,
   approver,
+  receiver,
 }: MilestoneProps) => {
   const cardVariants = {
     hidden: { opacity: 0, y: 20 },
@@ -109,17 +112,43 @@ export const MilestoneCard = ({
               </div>
             )}
 
-            {(signer || approver) && (
-              <div className="flex flex-col gap-1 mt-2 text-xs text-muted-foreground">
+            {(receiver || signer || approver) && (
+              <div className="mt-3">
+                {receiver && (
+                  <DetailRow
+                    label="Receiver"
+                    value={receiver}
+                    tooltip={
+                      tooltips.milestone_receiver ||
+                      "Address that receives the funds for this milestone."
+                    }
+                    canCopy
+                    isAddress
+                  />
+                )}
                 {signer && (
-                  <span>
-                    <span className="font-medium">Signer:</span> {signer}
-                  </span>
+                  <DetailRow
+                    label="Signer"
+                    value={signer}
+                    tooltip={
+                      tooltips.milestone_signer ||
+                      "Address authorized to release this milestone."
+                    }
+                    canCopy
+                    isAddress
+                  />
                 )}
                 {approver && (
-                  <span>
-                    <span className="font-medium">Approver:</span> {approver}
-                  </span>
+                  <DetailRow
+                    label="Approver"
+                    value={approver}
+                    tooltip={
+                      tooltips.milestone_approver ||
+                      "Address that approves this milestone."
+                    }
+                    canCopy
+                    isAddress
+                  />
                 )}
               </div>
             )}

--- a/src/lib/escrow-constants.ts
+++ b/src/lib/escrow-constants.ts
@@ -49,6 +49,7 @@ export const FIELD_TOOLTIPS: { [key: string]: string } = {
   milestone_description: "Details of the milestone's deliverable.",
   milestone_status: "Indicates if milestone is pending or completed.",
   milestone_approved: "Set to true if the milestone has been approved.",
+  milestone_receiver: "Address that receives the funds for this milestone.",
   title: "Title of the escrow contract.",
   description: "Description of the escrow purpose.",
   trustline: "Stellar asset that is used for the escrow.",

--- a/src/mappers/escrow-mapper.ts
+++ b/src/mappers/escrow-mapper.ts
@@ -17,6 +17,7 @@ export interface ParsedMilestone {
   resolved_flag?: boolean;
   signer?: string;
   approver?: string;
+  receiver?: string;
 }
 
 export type EscrowFlags = {
@@ -48,6 +49,19 @@ function getAddr(
 ): string | undefined {
   const v = m[k] as unknown;
   return isAddrLike(v) ? v.address : undefined;
+}
+// Reads an address from the first matching key. The multi-release milestone
+// schema names the per-milestone payee `receiver`, but tolerate the known
+// alternates so a contract revision doesn't silently drop the field.
+function getAddrAny(
+  m: Record<string, EscrowValue>,
+  keys: string[],
+): string | undefined {
+  for (const k of keys) {
+    const addr = getAddr(m, k);
+    if (addr) return addr;
+  }
+  return undefined;
 }
 function getBool(
   m: Record<string, EscrowValue>,
@@ -372,6 +386,12 @@ export const extractMilestones = (
             resolved_flag,
             signer: getAddr(milestoneMap, "signer"),
             approver: getAddr(milestoneMap, "approver"),
+            receiver: getAddrAny(milestoneMap, [
+              "receiver",
+              "receiver_address",
+              "recipient",
+              "recipient_address",
+            ]),
           },
         ];
       }


### PR DESCRIPTION
Closes #65

## What

Multi-release escrows can set a receiver per milestone, so each milestone may pay out to a different address. The viewer never showed this, which made it unclear where each milestone's funds would actually go. This adds the receiver to every multi-release milestone card.

## Changes

- `escrow-mapper.ts` — added `receiver` to `ParsedMilestone` and pull it out of the milestone map in `extractMilestones`. The live field is `receiver`; I kept `receiver_address` / `recipient` / `recipient_address` as fallbacks so a future schema rename doesn't silently drop it.
- `milestone-card.tsx` — render the receiver using the existing `DetailRow`, the same component the role cards use for addresses. That gives us the monospace pill, truncation, and copy button for free instead of a one-off bit of markup. Signer and approver moved onto the same row so the address section is consistent.
- `desktop-view.tsx` / `tab-view.tsx` — pass `receiver` through to the card on both render paths.
- `escrow-constants.ts` — tooltip copy for the receiver row.

## How I verified the field name

The issue (rightly) said not to guess, so I queried real testnet escrows over Soroban RPC and dumped the raw milestone storage. The milestone struct is `amount, description, evidence, flags, receiver, status` — confirmed the key is `receiver` across single- and multi-milestone escrows.

## Testing

Loaded several testnet escrows in the running app:
- Single milestone — receiver shows, long address truncates and copies.
- Multi-milestone (desktop grid + mobile tabs) — each card shows its own receiver.
- Single-release escrows are untouched (receiver only parsed for multi-release).

One note: the milestone-level signer/approver fields don't exist in the current contract version, so those rows simply don't render for these escrows — expected, and they stay optional.

**Proof**
<img width="2256" height="986" alt="image" src="https://github.com/user-attachments/assets/d725547c-f9ac-49a8-ad00-47b5bcb092e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone cards now display receiver address information with tooltips and copy functionality, shown alongside existing signer and approver details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->